### PR TITLE
Fix headings on installation page

### DIFF
--- a/content/0.0install.md
+++ b/content/0.0install.md
@@ -60,25 +60,31 @@ For example, if you installed Go to your home directory you should add the follo
 Download the package file, open it, and follow the prompts to install the Go tools. The package installs the Go distribution to `/usr/local/go`.
 
 The package should put the `/usr/local/go/bin directory` in your PATH environment variable. You may need to restart any open Terminal sessions for the change to take effect.
-Windows
+
+### Windows
 
 The Go project provides two installation options for Windows users (besides installing from source): a zip archive that requires you to set some environment variables and an MSI installer that configures your installation automatically.
-MSI installer
+
+#### MSI installer
 
 Open the MSI file and follow the prompts to install the Go tools. By default, the installer puts the Go distribution in c:\Go.
 
 The installer should put the ```c:\Go\bin``` directory in your PATH environment variable. You may need to restart any open command prompts for the change to take effect.
-Zip archive
+
+
+#### Zip archive
 
 Download the zip file and extract it into the directory of your choice (we suggest c:\Go).
 
 If you chose a directory other than ```c:\Go```, you must set the GOROOT environment variable to your chosen path.
 
 Add the bin subdirectory of your Go root (for example, ```c:\Go\bin```) to your PATH environment variable.
-Setting environment variables under Windows
+
+#### Setting environment variables under Windows
 
 Under Windows, you may set environment variables through the "Environment Variables" button on the "Advanced" tab of the "System" control panel. Some versions of Windows provide this control panel through the "Advanced System Settings" option inside the "System" control panel.
-Test your installation
+
+### Test your installation
 
 Check that Go is installed correctly by setting up a workspace and building a simple program, as follows.
 
@@ -110,12 +116,14 @@ The above command will put an executable command named hello (or hello.exe) insi
 If you see the "hello, world" message then your Go installation is working.
 
 Before rushing off to write Go code please read the How to Write Go Code document, which describes some essential concepts about using the Go tools.
-Uninstalling Go
+
+### Uninstalling Go
 
 To remove an existing Go installation from your system delete the go directory. This is usually `/usr/local/go` under Linux, Mac OS X, and FreeBSD or `c:\Go` under Windows.
 
 You should also remove the Go bin directory from your PATH environment variable. Under Linux and FreeBSD you should edit `/etc/profile` or `$HOME/.profile`. If you installed Go with the Mac OS X package then you should remove the `/etc/paths.d/go` file. Windows users should read the section about setting environment variables under Windows.
-Getting help
+
+### Getting help
 
 For real-time help, ask the helpful gophers in ```#go-nuts``` on the Freenode IRC server.
 


### PR DESCRIPTION
I just started reading the book and notice that some headings are showing as regular text instead of headings.