### PR TITLE
Chapter 2: Designing App - Remove redeclaration of variable

### DIFF
--- a/manuscript/2.1WebAppDesign.md
+++ b/manuscript/2.1WebAppDesign.md
@@ -71,9 +71,9 @@ Create all functions we mentioned above and make the necessary changes as per on
     func ShowAllTasksFunc(w http.ResponseWriter, r *http.Request) {
         var message string
         if r.Method == "GET" {
-            message := "all pending tasks GET"
+            message = "all pending tasks GET"
         } else {
-            message := "all pending tasks POST"
+            message = "all pending tasks POST"
         }
         w.Write([]byte(message))
     }


### PR DESCRIPTION
The `message` var was being redeclared inside the conditional statements and `go build` was throwing this error: `message declared and not used`. Replacing the `:=` operator with `=` got rid of the errors.