### PR TITLE
Remove duplicated 'go run'

### DIFF
--- a/manuscript/0.1tools.md
+++ b/manuscript/0.1tools.md
@@ -124,7 +124,6 @@ Go provides more commands than those we've just talked about.
 	go version // get information about your version of Go
 	go env // view environment variables about Go
 	go list // list all installed packages
-	go run // compile temporary files and run the application
 
 For details about specific commands, `go help <command>`.
 


### PR DESCRIPTION
'go run' has it's own section above and then was mentioned in the other commands section