### PR TITLE
Fixed markdown formatting in 4.0authentification.md

### DIFF
--- a/manuscript/4.0authentication.md
+++ b/manuscript/4.0authentication.md
@@ -1,4 +1,4 @@
-#Authentication
+# Authentication
 
 Authentication is used to verify if the users have access to that particular part of your web application. For understanding how to implement authentication we need to understand what happens behind the scenes of a browser. Suppose we run a bank, we want only our legitimate users to access our application. We set up a login page and provide our users with their username and password which they can use to validate their claim to our webapp.
 
@@ -10,7 +10,7 @@ We can send the username along with each HTTP request, either in the URL via a G
 
 To solve this problems Sessions were invented, sessions need to use cookies on the browser to function. The basic idea is that the server generates a sessionID and store it in a cookie on the browser. With subsequent requests, the browser will send the sessionID along with the request, the webserver will then come to know from that sessionID if the request is a fake one or not. Also we get to know who the user is from that.
 
-##Cookies
+## Cookies
 
 Cookies, as we saw in a previous chapter can be used to store a key, value pair on the user's browser. We used a cookie to store the CSRF token, the cookie had the name as CSRF and value as the token.
 
@@ -47,13 +47,13 @@ aware and we have set the HttpOnly field to true while setting the cookie. This 
 
 One has to remember that cookie is nothing but a file stored in a user's browser, if can be accessed over HTTP by our webserver, a client browser does allow access to it through browser settings or custom javascript. The browser, after all is a platform, and  we have APIs to that platform.
 
-##Sessions
+## Sessions
 
 A session is a series of actions performed between you and the webapp you are acting, enabled by the browser and the Internet you are using. 
 
 While generating a new session, we need to check if a sessions is already active, if so we return the same session ID rather than create a new one, if not, we generate a new session ID. Session IDs need to be sufficiently random. Of course we can't generate something totally random, but we have to ensure to generate something that nobody else can replicate, unless they have access to our private key which we use to generate our random number.
 
-####Session handling using gorilla/sessions
+#### Session handling using gorilla/sessions
 
 Till now we never used any third party library or a framework in this book, this is for the first time that we are doing so, we better use libraries for handling sessions, since security is the primary aspect of any web application it is wiser to use existing (and good) packages to manage security.
 
@@ -177,9 +177,9 @@ func LoginFunc(w http.ResponseWriter, r *http.Request) {
 ```
 There is a better way of handling sessions using middleware, we'll introduce that concept in the next chapter.
 
-##Users
+## Users
 
-####Signing users up
+#### Signing users up
 
 The above example just hardcodes the username and password, of course we'd want people to sign up to our service. We create a user table.
 
@@ -240,7 +240,7 @@ We saw TaskQuery in our chapter on DB, it is a simple wrapper around db.Exec().
 >Note: 
 In a real web app, you'd want to encrypt the password and not store it in plain text, this is a dummy app which'll never see the light of the day so I am keeping it plaintext.
 
-####Login
+#### Login
 
 file `~/Tasks/views/sessionViews.go`
 
@@ -310,6 +310,6 @@ Since we are using gorilla/sessions, we just have to plugin the functionality th
 
 We keep resetting the password as an exercise, formulate a mechanism to resetting the password, requires us to create a user table and store some profile information, either email-ID from where we'll send a security code or by doing something else! Brainstorm!
 
-#####Links
+##### Links
 -[Previous section](3.0templating.md)
 -[Next section](5.0Files.md)


### PR DESCRIPTION
I was referred to this page after asking a question on reddit and noticed that the markdown for the headers was not formatted properly. There was no space after the #s, so they were showing up in the actual displayed file. I don’t know if this occurs in any of the other files in this repository, but I thought I’d fix this one real quick. Hope it helps.