### PR TITLE
Add missing required whitespace to fix header generation

### DIFF
--- a/manuscript/0.1tools.md
+++ b/manuscript/0.1tools.md
@@ -50,7 +50,7 @@ It has two interfaces:
 	The packages where comments aren't present show up as blank pages in godoc.
 
 
-####Documentation
+#### Documentation
 
 The documentation covered by godoc is the documentation about the API, since only the exported functions have documentation comments in godoc. This documentation is different from the logic documentation.
 
@@ -68,7 +68,7 @@ Example: `go build -o tasks`
 
 By default, `go build` builds the entire application and the depending libraries, into a static binary and later throws all away. This results in rebuilding everything every single time `go build` is executed. For caching the library builds, use `go install` first and `go build` later.
 
-######Cross compilation
+###### Cross compilation
 
 Go allows cross compilation. We have to pass the OS name as linux/darwin/windows as GOOS as shown in the below commands.
 

--- a/manuscript/02.1IntroductionGo.md
+++ b/manuscript/02.1IntroductionGo.md
@@ -100,7 +100,7 @@ Here, we are in the Tasks/main directory, the binary will expect all the other f
 
 There can be only _one_ main package & function per executable program. The main function takes no arguments passed and returns nothing.
 
-#####Links
+##### Links
 
 -[Previous section](0.1tools.md)
 -[Next section](02.2VariablesDataStruct.md)

--- a/manuscript/02.2VariablesDataStruct.md
+++ b/manuscript/02.2VariablesDataStruct.md
@@ -56,6 +56,7 @@ func main() {
 	var i int
 }
 ```
+
 ## Constants
 
 Constants are the values that are determined during compile time that cannot be changed during runtime. In Go, you can use number, boolean or string as types of constants.
@@ -75,6 +76,7 @@ const i = 10000
 const MaxThread = 10
 const prefix = "astaxie_"
 ```
+
 ## Elementary types
 
 #### Boolean
@@ -513,7 +515,7 @@ bool    false
 string  ""
 ```
 
-#####Links
+##### Links
 
 -[Previous section](02.1IntroductionGo.md)
 -[Next section](02.3CntrlStmtFunctions.md)

--- a/manuscript/02.5ObjectOriented.md
+++ b/manuscript/02.5ObjectOriented.md
@@ -98,7 +98,7 @@ One thing that's worth noting is that the method with a dotted line means the re
 
 Any type can be the receiver of a method.
 
-######Custom data types
+###### Custom data types
 
 Use the following format to define a custom type.
 

--- a/manuscript/02.6Interface.md
+++ b/manuscript/02.6Interface.md
@@ -190,7 +190,7 @@ a = s
 
 If a function uses an empty interface as its argument type, it can accept any type; if a function uses empty interface as its return value type, it can return any type.
 
-####Method arguments of an interface
+#### Method arguments of an interface
 
 Any variable can be used in an interface. So how can we use this feature to pass any type of variable to a function?
 
@@ -420,6 +420,7 @@ p := reflect.ValueOf(&x)
 v := p.Elem()
 v.SetFloat(7.1)
 ```
+
 ##### Links
 
 -[Previous section](02.5ObjectOriented.md)

--- a/manuscript/02.7Concurrency.md
+++ b/manuscript/02.7Concurrency.md
@@ -194,6 +194,7 @@ func main() {
 }
 ```	
 `select` has a `default` case as well, just like `switch`. When all the channels are not ready for use, it executes the default case (it doesn't wait for the channel anymore).
+
 ```golang
 select {
 case i := <-c:
@@ -202,9 +203,11 @@ default:
 	// executes here when c is blocked
 }
 ```	
+
 #### Timeout
 
 Sometimes a goroutine becomes blocked. How can we avoid this to prevent the whole program from blocking? It's simple, we can set a timeout in the select.
+
 ```golang
 func main() {
 	c := make(chan int)
@@ -224,6 +227,7 @@ func main() {
 	<- o
 }
 ```
+
 #### Runtime goroutine
 
 The package `runtime` has some functions for dealing with goroutines.

--- a/manuscript/1.0generalTalk.md
+++ b/manuscript/1.0generalTalk.md
@@ -44,7 +44,7 @@ For the Tasks app, it resides in `$GOPATH/src/github/thewhitetulip/Tasks`, thus,
 
 >There is a workaround for this by treating `$GOPATH/src` itself as your entire project and having libraries directly inside it. This is not the Go way of doing things. Please do not do it.
 
-##Internal deployment
+## Internal deployment
 
 We'll follow the standard practice and put our code in `$GOPATH/src/github.com/thewhitetulip/Tasks` folder. While testing our app, we need a deployment version. I used `Tasks` while building Tasks, I have made a folder `~/Tasks` and here I keep the deployment version of Tasks, which contains the binary version and the static files. Every new build in the `src` gets pushed in this folder.
 

--- a/manuscript/1.1WebProgramBasics.md
+++ b/manuscript/1.1WebProgramBasics.md
@@ -24,7 +24,7 @@ Writing a server might sound like very difficult, but it is not. To the core, a 
 
 The browser just abstracts the users from sending and receiving the HTTP request/responses. Everything that a browser does can be done programmatically,
 
-##HTTP Methods
+## HTTP Methods
 
 Two important parts of a HTTP Request are Methods and URL. The URL states what the user wants to do (/logout or /login or /posts), and the Method states the semantics of the request, for instance the user might be sending a Form using the POST method or the user is wanting a list of posts using the GET method.
 
@@ -102,7 +102,7 @@ Writing a web application:
 ###### Not abusing templates
 The logic behind creating templates was to avoid duplication of HTML code. Templates are to be used only for the presentation logic *not* the business logic. Adding business logic in templates makes it very difficult to maintain the app. 
 
-####Example:
+#### Example:
 We are going to build a todo list manager in this book with supports multiple users.
 
 Wrong way: Fetch all tasks in the template and only show those of the current user. i.e. filter the tasks in the template

--- a/manuscript/2.2database.md
+++ b/manuscript/2.2database.md
@@ -118,7 +118,7 @@ Now you’re ready to access a database.
 
 Every database has a connection mechanism, file for sqlite and IP address for MySQL/Postgres.
 
-#Retrieving Result Sets
+# Retrieving Result Sets
 
 There are several idiomatic operations to retrieve results from the datastore.
 
@@ -129,7 +129,7 @@ There are several idiomatic operations to retrieve results from the datastore.
 
 Go’s database/sql function names are significant. If a function name includes `Query`, it is designed to **ask a question of the database**, and will return a set of rows, even if it’s empty. Statements that don’t return rows should not use Query functions; they should use Exec().
 
-##Fetching Data from the Database
+## Fetching Data from the Database
 
 Let’s take a look at an example of how to query the database, working with results. We’ll query the users table for a user whose id is 1, and print out the user’s id and name. We will assign results to variables, a row at a time, with rows.Scan().
 
@@ -256,7 +256,7 @@ A couple parts of this are easy to get wrong, and can have bad consequences.
 * You should always defer rows.Close(), even if you also call rows.Close() explicitly at the end of the loop, which isn’t a bad idea.
 * Don’t defer within a loop. A deferred statement doesn’t get executed until the function exits, so a long-running function shouldn’t use it. If you do, you will slowly accumulate memory. If you are repeatedly querying and consuming result sets within a loop, you should explicitly call rows.Close() when you’re done with each result, and not use defer.
 
-##How Scan() Works
+## How Scan() Works
 
 When you iterate over rows and scan them into destination variables, Go performs data type conversions work for you, behind the scenes. It is based on the type of the destination variable. Being aware of this can clean up your code and help avoid repetitive work.
 
@@ -264,7 +264,7 @@ For example, suppose you select some rows from a table that is defined with stri
 
 Or, you can just pass Scan() a pointer to an integer. Go will detect that and call strconv.ParseInt() for you. If there’s an error in conversion, the call to Scan() will return it. Your code is neater and smaller now. This is the recommended way to use database/sql.
 
-##Preparing Queries
+## Preparing Queries
 
 You should, in general, always prepare queries to be used multiple times. The result of preparing the query is a prepared statement, which can have placeholders (a.k.a. bind values) for parameters that you’ll provide when you execute the statement. This is much better than concatenating strings, for all the usual reasons (avoiding SQL injection attacks, for example).
 
@@ -292,7 +292,7 @@ if err = rows.Err(); err != nil {
 
 Under the hood, db.Query() actually prepares, executes, and closes a prepared statement. That’s three round-trips to the database. If you’re not careful, you can triple the number of database interactions your application makes! Some drivers can avoid this in specific cases, but not all drivers do. See prepared statements for more.
 
-##Single-Row Queries
+## Single-Row Queries
 
 If a query returns at most one row, you can use a shortcut around some of the lengthy boilerplate code:
 
@@ -326,12 +326,12 @@ if err != nil {
 fmt.Println(taskDescription)
 ```
 
-#Modifying Data and Using Transactions
+# Modifying Data and Using Transactions
 
 Now we’re ready to see how to modify data and work with transactions. The distinction might seem artificial if you’re used to programming languages that use a “statement” object for fetching rows as well as updating data, but in Go, there’s an important reason for the difference.
 
 
-##Statements that Modify Data
+## Statements that Modify Data
 
 Use Exec(), preferably with a prepared statement, to accomplish an INSERT, UPDATE, DELETE, or other statement that doesn’t return rows. The following example shows how to insert a row and inspect metadata about the operation:
 
@@ -366,7 +366,7 @@ _, err := db.Query("DELETE FROM users") // BAD
 
 The answer is no. They do not do the same thing, and you should never use Query() like this. The Query() will return a sql.Rows, which reserves a database connection until the sql.Rows is closed. Since there might be unread data (e.g. more data rows), the connection can not be used. In the example above, the connection will never be released again. The garbage collector will eventually close the underlying net.Conn for you, but this might take a long time. Moreover the database/sql package keeps tracking the connection in its pool, hoping that you release it at some point, so that the connection can be used again. This anti-pattern is therefore a good way to run out of resources (too many connections, for example).
 
-##Working with Transactions
+## Working with Transactions
 
 In Go, a transaction is essentially an object that reserves a connection to the datastore. It lets you do all of the operations we’ve seen thus far, but guarantees that they’ll be executed on the same connection.
 
@@ -453,7 +453,7 @@ This can result in apparent leaks of statements, statements being prepared and
 re-prepared more often than you think, and even running into server-side limits
 on the number of statements.
 
-##Avoiding Prepared Statements
+## Avoiding Prepared Statements
 
 Go creates prepared statements for you under the covers. A simple
 `db.Query(sql, param1, param2)`, for example, works by preparing the sql, then
@@ -477,7 +477,7 @@ or `db.QueryRow()`. And your driver needs to support plaintext query execution,
 which is added in Go 1.1 via the `Execer` and `Queryer` interfaces,
 [documented here](http://golang.org/pkg/database/sql/driver/#Execer).
 
-##Prepared Statements in Transactions
+## Prepared Statements in Transactions
 
 Prepared statements that are created in a `Tx` are bound exclusively to
 it, so the earlier cautions about repreparing do not apply. When
@@ -529,7 +529,7 @@ underlying connection, rendering the connection state inconsistent.
 If you use Go 1.4 or older, you should make sure the statement is always closed before the transaction is
 committed or rolled back. [This issue](https://github.com/golang/go/issues/4459) was fixed in Go 1.4 by [CR 131650043](https://codereview.appspot.com/131650043).
 
-##Parameter Placeholder Syntax
+## Parameter Placeholder Syntax
 
 The syntax for placeholder parameters in prepared statements is
 database-specific. For example, comparing MySQL, PostgreSQL, and Oracle:
@@ -539,7 +539,7 @@ database-specific. For example, comparing MySQL, PostgreSQL, and Oracle:
     WHERE col = ?       WHERE col = $1        WHERE col = :col
     VALUES(?, ?, ?)     VALUES($1, $2, $3)    VALUES(:val1, :val2, :val3)
 
-#Handling Errors
+# Handling Errors
 
 Almost all operations with `database/sql` types return an error as the last
 value. You should always check these errors, never ignore them.
@@ -547,7 +547,7 @@ value. You should always check these errors, never ignore them.
 There are a few places where error behavior is special-case, or there's
 something additional you might need to know.
 
-##Errors From Iterating Resultsets
+## Errors From Iterating Resultsets
 
 Consider the following code:
 
@@ -567,7 +567,7 @@ need to check whether the loop terminated normally or not. An abnormal
 termination automatically calls `rows.Close()`, although it's harmless to call it
 multiple times.
 
-##Errors From Closing Resultsets
+## Errors From Closing Resultsets
 
 You should always explicitly close a `sql.Rows` if you exit the loop
 prematurely, as previously mentioned. It's auto-closed if the loop exits
@@ -592,7 +592,7 @@ that it's best to capture and check for errors in all database operations. If
 Logging the error message or panicing might be the only sensible thing,
 and if that's not sensible, then perhaps you should just ignore the error.
 
-##Errors From QueryRow()
+## Errors From QueryRow()
 
 Consider the following code to fetch a single row:
 
@@ -689,7 +689,7 @@ if driverErr, ok := err.(*mysql.MySQLError); ok {
 }
 ```
 
-##Handling Connection Errors
+## Handling Connection Errors
 
 What if your connection to the database is dropped, killed, or has an error?
 
@@ -706,7 +706,7 @@ One example that has occurred with the MySQL driver is that using `KILL` to
 cancel an undesired statement (such as a long-running query) results in the
 statement being retried up to 10 times.
 
-#Working with NULLs
+# Working with NULLs
 
 Nullable columns are annoying and lead to a lot of ugly code. If you can, avoid
 them. If not, then you'll need to use special types from the `database/sql`
@@ -813,7 +813,7 @@ for rows.Next() {
 }
 ```
 
-#The connection pool
+# The connection pool
 
 There is a basic connection pool in the database/sql package. There isn’t a lot of ability to control or inspect it, but here are some things you might find useful to know:
 
@@ -825,13 +825,13 @@ There is a basic connection pool in the database/sql package. There isn’t a lo
 1. Connections are recycled rather fast. Setting a high number of idle connections with db.SetMaxIdleConns(N) can reduce this churn, and help keep connections around for reuse.
 1. Keeping a connection idle for a long time can cause problems (like in this issue with MySQL on Microsoft Azure). Try db.SetMaxIdleConns(0) if you get connection timeouts because a connection is idle for too long.
 
-#Surprises, Antipatterns and Limitations
+# Surprises, Antipatterns and Limitations
 
 Although `database/sql` is simple once you're accustomed to it, you might be
 surprised by the subtlety of use cases it supports. This is common to Go's core
 libraries.
 
-##Resource Exhaustion
+## Resource Exhaustion
 
 As mentioned throughout this site, if you don't use `database/sql` as intended,
 you can certainly cause trouble for yourself, usually by consuming some
@@ -842,7 +842,7 @@ resources or preventing them from being reused effectively:
 * Using `Query()` for a statement that doesn't return rows will reserve a connection from the pool.
 * Failing to be aware of how [prepared statements](prepared.html) work can lead to a lot of extra database activity.
 
-##Large uint64 Values
+## Large uint64 Values
 
 Here's a surprising error. You can't pass big unsigned integers as parameters to
 statements if their high bit is set:
@@ -855,7 +855,7 @@ This will throw an error. Be careful if you use `uint64` values, as they may
 start out small and work without error, but increment over time and start
 throwing errors.
 
-##Connection State Mismatch
+## Connection State Mismatch
 
 Some things can change connection state, and that can cause problems for two
 reasons:
@@ -876,13 +876,13 @@ potentially pollute the state for some other code. This is one of the reasons
 why you should never issue BEGIN or COMMIT statements as SQL commands directly,
 too.
 
-##Database-Specific Syntax
+## Database-Specific Syntax
 
 The `database/sql` API provides an abstraction of a row-oriented database, but
 specific databases and drivers can differ in behavior and/or syntax, such as
 [prepared statement placeholders](prepared.html).
 
-##Multiple Result Sets
+## Multiple Result Sets
 
 The Go driver doesn't support multiple result sets from a single query in any
 way, and there doesn't seem to be any plan to do that, although there is [a
@@ -892,7 +892,7 @@ supporting bulk operations such as bulk copy.
 This means, among other things, that a stored procedure that returns multiple
 result sets will not work correctly.
 
-##Invoking Stored Procedures
+## Invoking Stored Procedures
 
 Invoking stored procedures is driver-specific, but in the MySQL driver it can't
 be done at present. It might seem that you'd be able to call a simple
@@ -909,7 +909,7 @@ multi-statement mode, even for a single result, and the driver doesn't currently
 do that (though see [this
 issue](https://github.com/go-sql-driver/mysql/issues/66)).
 
-##Multiple Statement Support
+## Multiple Statement Support
 
 The `database/sql` doesn't explicitly have multiple statement support, which means
 that the behavior of this is backend dependent:
@@ -956,7 +956,7 @@ first has released its resources and cleaned up after itself.  This also means
 that each statement in a transaction results in a separate set of network
 round-trips to the database.
 
-#Database Encapsulation
+# Database Encapsulation
 
 We encapsulate our db object inside a struct. We also encapsulate the database actions as shown below
 

--- a/manuscript/2.5UploadingFiles.md
+++ b/manuscript/2.5UploadingFiles.md
@@ -122,6 +122,7 @@ func UploadedFileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 ```
+
 ##### Links
 -[Previous section](2.4WorkingWithForms.md)
 -[Next section](3.0templating.md)

--- a/manuscript/8.0buildingAPI.md
+++ b/manuscript/8.0buildingAPI.md
@@ -260,7 +260,7 @@ For executing the above code, we need to ensure that our Tasks application is ru
 
 This might be a great example to get started with using HTTP methods from Go, but for our application we require to send POST reqests with content type as form and send the form data as request body.
 
-##Getting the token
+## Getting the token
 
 We use the PostForm method which will send a Form via a POST method, effectively saving the trouble of setting the content type field for us. If you run the below code, it will print the authentication token on the terminal.
 

--- a/manuscript/links.py
+++ b/manuscript/links.py
@@ -9,7 +9,7 @@ for i in range(len(lines)):
 	prev = i - 1
 	if i != len(lines) -1 :
 		nxt = i+1
-	curfile.write("\n#####Links\n")
+	curfile.write("\n##### Links\n")
 	curfile.write("-[Previous section]("+lines[prev]+")\n")
 	if i != len(lines) - 1:
 		curfile.write("-[Next section]("+lines[nxt]+")\n")


### PR DESCRIPTION
I fixed those I spotted, including some missing newlines after code blocks which caused headers following those code blocks to also not render properly. I suspect I missed a few based on my using a regex pattern to find affected headers.

I found a few headers which were potentially the wrong header level, but did not include those changes in this PR.

fixes #98