### PR TITLE
Fix name of variable in description

### DIFF
--- a/manuscript/02.2VariablesDataStruct.md
+++ b/manuscript/02.2VariablesDataStruct.md
@@ -280,7 +280,7 @@ Go is concise because it has some default behaviors.
 
 #### array
 
-`array` is an array, we define one as follows.
+`arr` is an array, we define one as follows.
 
 ```golang
 var arr [n]type


### PR DESCRIPTION
I'm not 100% sure about this one, but I think you meant `arr` in the description to refer to the `arr` variable defined in the next line.